### PR TITLE
Add some tests for Bitcrusher, Chorus and Filter nodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+tests/bower_components

--- a/tests/RUN_TESTS.md
+++ b/tests/RUN_TESTS.md
@@ -1,0 +1,31 @@
+# Running tests
+
+Tests depend on the [Jasmine](http://jasmine.github.io/) testing framework,
+currently using v. 2.3.4, and are run in the browser in two different ways.
+ 
+## Remote mode
+
+In remote mode, the Jasmine files are loaded on the fly from the CLoudflare
+CDN. Load the `$TUNA_BRANCH_ROOT/tests/online-runner.html` file in your
+browser: you should see a test output page with zero failures.
+
+## Local mode
+
+In local mode, first install the Jasmine files inside your local branch by
+using the Bower package manager. If you don't have it, install it by using the
+NPM package manager. If you don't have the latter either, install it too.
+Yes, it's messy.
+
+The following works for Ubuntu and Debian, adapt it to your system:
+
+```
+$ sudo apt-get install npm
+$ sudo npm install -g bower
+$ cd $TUNA_BRANCH_ROOT/tests
+$ bower install jasmine
+```
+
+If all went well, there will be a newly created
+`$TUNA_BRANCH_ROOT/tests/bower_components` directory. Now load the
+`$TUNA_BRANCH_ROOT/tests/offline-runner.html` file in your browser: you should
+see the same output page as in remote mode.

--- a/tests/offline-runner.html
+++ b/tests/offline-runner.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Jasmine Test Runner</title>
+
+  <link rel="shortcut icon" type="image/png" href="bower_components/jasmine/images/jasmine_favicon.png">
+  <link rel="stylesheet" href="bower_components/jasmine/lib/jasmine-core/jasmine.css">
+
+  <script src="bower_components/jasmine/lib/jasmine-core/jasmine.js"></script>
+  <script src="bower_components/jasmine/lib/jasmine-core/jasmine-html.js"></script>
+  <script src="bower_components/jasmine/lib/jasmine-core/boot.js"></script>
+
+  <!-- source files -->
+  <script src="../tuna.js"></script>
+
+  <!-- test files -->
+  <script src="tests.js"></script>
+
+</head>
+
+<body>
+</body>
+</html>

--- a/tests/online-runner.html
+++ b/tests/online-runner.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Jasmine Test Runner v2.3.4</title>
+
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jasmine/2.3.4/jasmine.min.css">
+
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jasmine/2.3.4/jasmine.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jasmine/2.3.4/jasmine-html.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jasmine/2.3.4/boot.min.js"></script>
+
+  <!-- source files -->
+  <script src="../tuna.js"></script>
+
+  <!-- test files -->
+  <script src="tests.js"></script>
+
+</head>
+
+<body>
+</body>
+</html>

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -1,0 +1,105 @@
+describe("In Tuna", function() {
+  var context, tuna;
+
+  beforeAll(function() {
+    context = new OfflineAudioContext(1, 128, 44100);
+    tuna = new Tuna(context);
+  });
+
+
+  describe("a Filter node", function() {
+    var filter;
+
+    beforeEach(function() {
+      filter = new tuna.Filter({
+        frequency: 400,
+        // Why "resonance" rather than "Q" as elsewhere?
+        resonance: 2,
+        gain: 2,
+        filterType: "highpass",
+        bypass: true
+      });
+    });
+
+    it("will be checked", function() {
+      expect(filter.frequency.value).toEqual(400);
+      expect(filter.Q.value).toEqual(2);
+      expect(filter.gain.value).toEqual(2);
+      expect(filter.filterType).toEqual("highpass");
+      expect(filter.bypass).toBeTruthy();
+      expect(filter.input.numberOfInputs).toEqual(1);
+      expect(filter.output.numberOfOutputs).toEqual(1);
+    });
+
+    it("will be activated", function() {
+      filter.activateCallback = jasmine.createSpy();
+      filter.bypass = false;
+      expect(filter.activateCallback).toHaveBeenCalled();
+    });
+
+  });
+
+
+  describe("a Bitcrusher node", function() {
+    var bitcrusher;
+
+    beforeEach(function() {
+      bitcrusher = new tuna.Bitcrusher({
+        bits: 5,
+        normfreq: 0.2,
+        bufferSize: 2048,
+        bypass: true
+      });
+    });
+
+    it("will be checked", function() {
+      expect(bitcrusher.bits).toEqual(5);
+      expect(bitcrusher.normfreq).toEqual(0.2);
+      expect(bitcrusher.bufferSize).toEqual(2048);
+      expect(bitcrusher.bypass).toBeTruthy();
+      expect(bitcrusher.input.numberOfInputs).toEqual(1);
+      expect(bitcrusher.output.numberOfOutputs).toEqual(1);
+    });
+
+    it("will be activated", function() {
+      bitcrusher.activateCallback = jasmine.createSpy();
+      bitcrusher.bypass = false;
+      expect(bitcrusher.activateCallback).toHaveBeenCalled();
+    });
+
+  });
+
+
+  describe("a Chorus node", function() {
+    var chorus;
+
+    beforeEach(function() {
+      chorus = new tuna.Chorus({
+        rate: 1.0,
+        feedback: 0.2,
+        delay: 0.05,
+        depth: 0.5,
+        bypass: true
+      });
+    });
+
+    it("will be checked", function() {
+      expect(chorus.rate).toEqual(1.0);
+      expect(chorus.feedback).toEqual(0.2);
+      expect(chorus.delay).toBeCloseTo(0.00045, 5);
+      // tuna.js#523 looks weird.
+      expect(chorus.depth).toEqual(0.5);
+      expect(chorus.bypass).toBeTruthy();
+      expect(chorus.input.numberOfInputs).toEqual(1);
+      expect(chorus.output.numberOfOutputs).toEqual(1);
+    });
+
+    it("will be activated", function() {
+      chorus.activateCallback = jasmine.createSpy();
+      chorus.bypass = false;
+      expect(chorus.activateCallback).toHaveBeenCalled();
+    });
+
+  });
+
+});


### PR DESCRIPTION
With instructions on how to run tests by loading the Jasmine file remotely, and also installing them locally using Bower. More tests will follow.

I could not find a way, in the Web Audio API, to detect what's connected to what. Any hint is appreciated.